### PR TITLE
Add docker-compose w/ postgres container for local dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3"
+
+services:
+  db:
+    image: postgres:9.6.3-alpine
+    restart: always
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_PASSWORD: 'postgres'
+    volumes:
+      - database_data:/var/lib/postgresql/data
+
+  api:
+    build:
+      context: ./
+      dockerfile: ./Dockerfile
+    volumes:
+      - ./:/usr/src/app:rw
+    ports:
+      - "5000:5000"
+    links:
+      - db
+    environment:
+      DB_PORT: "5432"
+      DB_HOSTNAME: "db"
+      DB_DATABASE: "postgres"
+      DB_USERNAME: "postgres"
+      DB_PASSWORD: "postgres"
+
+volumes:
+  # for persistance of database data
+  database_data:
+    driver: local

--- a/hardware.py
+++ b/hardware.py
@@ -6,9 +6,11 @@ import os
 
 application = Flask(__name__)
 
-DB_HOSTNAME=os.environ.get('DB_HOSTNAME')
-DB_USERNAME=os.environ.get('DB_USERNAME')
-DB_PASSWORD=os.environ.get('DB_PASSWORD')
+DB_HOSTNAME = os.environ.get('DB_HOSTNAME',"localhost")
+DB_PORT     = os.environ.get('DB_PORT', "5432")
+DB_DATABASE = os.environ.get('DB_DATABASE', "rescale")
+DB_USERNAME = os.environ.get('DB_USERNAME')
+DB_PASSWORD = os.environ.get('DB_PASSWORD')
 
 def slow_process_to_calculate_availability(provider, name):
     time.sleep(5)
@@ -18,11 +20,11 @@ def slow_process_to_calculate_availability(provider, name):
 @application.route('/hardware/')
 def hardware():
     try:
-        connection = psycopg2.connect(user = DB_USERNAME,
+        connection = psycopg2.connect(user     = DB_USERNAME,
                                       password = DB_PASSWORD,
-                                      host = DB_HOSTNAME,
-                                      port = "5432",
-                                      database = "rescale")
+                                      host     = DB_HOSTNAME,
+                                      port     = DB_PORT,
+                                      database = DB_DATABASE)
 
         cursor = connection.cursor()
 

--- a/startup.sh
+++ b/startup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # Create table and insert data into the DB if it doesn't exist
-echo "$DB_HOSTNAME:5432:rescale:postgres:$DB_PASSWORD" > ~/.pgpass; chmod 600 ~/.pgpass
-psql -h $DB_HOSTNAME -U $DB_USERNAME -d rescale -f psql-database.sql
+echo "$DB_HOSTNAME:$DB_PORT:$DB_DATABASE:$DB_USERNAME:$DB_PASSWORD" > ~/.pgpass; chmod 600 ~/.pgpass
+psql -h $DB_HOSTNAME -U $DB_USERNAME -d $DB_DATABASE -f psql-database.sql
 
 # Start the first process
 python portal.py &


### PR DESCRIPTION
This PR adds easy local dev with a postgres container using docker-compose.

## Using docker-compose
_Note: docker-compose commands should be called from project's root folder_
1. Create and start containers: `docker-compose up`
2. Test locally by visiting: http://0.0.0.0:5000/
3. Stop and remove all container resources: `docker-compose down`

Note: Sometimes `docker-compose rm` is required to kill stagnant containers. If you are getting unexpected behavior after docker-compose down and up commands you may want to try "rm".

# ⚠️ WARNING
I did not build AWS infrastructure so these changes haven't been tested against deploy to AWS. The changes made to startup.sh & hardware.py to use `DB_PORT`, `DB_DATABASE`, and `DB_USERNAME` env variables may break deploy.